### PR TITLE
优化错误图像读写机制

### DIFF
--- a/BeautifulReport/BeautifulReport.py
+++ b/BeautifulReport/BeautifulReport.py
@@ -435,13 +435,18 @@ class BeautifulReport(ReportTestResult, PATH):
             @wraps(func)
             def __wrap(*args, **kwargs):
                 img_path = os.path.abspath('{}'.format(BeautifulReport.img_path))
+                testclasstype = str(type(args[0]))
+                # print(testclasstype)
+                testclassnm = testclasstype[testclasstype.rindex('.')+1:-2]
+                # print(testclassnm)
+                img_nm = testclassnm + '_' + func.__name__
                 try:
                     result = func(*args, **kwargs)
                 except Exception:
                     if 'save_img' in dir(args[0]):
                         save_img = getattr(args[0], 'save_img')
-                        save_img(func.__name__)
-                        data = BeautifulReport.img2base(img_path, pargs[0] + '.png')
+                        save_img(os.path.join(img_path, img_nm + '.png'))
+                        data = BeautifulReport.img2base(img_path, img_nm + '.png')
                         print(HTML_IMG_TEMPLATE.format(data, data))
                     sys.exit(0)
                 print('<br></br>')

--- a/BeautifulReport/BeautifulReport.py
+++ b/BeautifulReport/BeautifulReport.py
@@ -435,6 +435,8 @@ class BeautifulReport(ReportTestResult, PATH):
             @wraps(func)
             def __wrap(*args, **kwargs):
                 img_path = os.path.abspath('{}'.format(BeautifulReport.img_path))
+                if not os.access(img_path, os.F_OK):
+                    os.makedirs(img_path)
                 testclasstype = str(type(args[0]))
                 # print(testclasstype)
                 testclassnm = testclasstype[testclasstype.rindex('.')+1:-2]


### PR DESCRIPTION
目前beautfulReport 读写error img这里处理不太好
保存图像的时候名字是用的测试方法的名字，路径是在自定义的save_img里指定的
而report里读图像名字是取的装饰器的参数，路径指定为了当前路径下的img，而运行testcase和suite当前路径是不同的
这样就导致我们在写save_img的时候也要指定对应的路径，运行test case和运行test suite时img路径也要不一样，而且装饰器里的参数也要和测试方法保持一致，不然report就会找不到img，放不到html里去
另一个问题就是如果不同test class下都有test_case1的话就互相覆盖了

我做了以下修改
图像路径统一用beautifulReport里指定的当前路径下的img，名字统一用'testclass_testmethod'
这样改之后读写img的路径就统一了，名字也不会重复，装饰器也不用传参